### PR TITLE
chore: Update main to use 1.5 track

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,7 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v1.0.0
     with:
-      track-name: 1.4
+      track-name: 1.5
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
@@ -64,6 +64,6 @@ jobs:
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v1.0.0
     with:
       branch-name: ${{ github.ref_name }}
-      track-name: 1.4
+      track-name: 1.5
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -15,6 +15,7 @@ on:
         description: Name of the charmhub track to publish
         options:
           - '1.4'
+          - '1.5'
           - latest
 
 jobs:


### PR DESCRIPTION
With 1.4 being released, main now publishes to 1.5