### PR TITLE
chore: Update TF provider version to 0.12 

### DIFF
--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.11.0"
+      version = "~> 0.12.0"
     }
   }
 }


### PR DESCRIPTION
Updates from ~> 0.11.0 to ~> 0.12.0 in /terraform