### PR TITLE
chore: add validation for gNB name in relation databag

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -43,6 +43,13 @@ class SdcoreGnbIntegratorCharm(ops.CharmBase):
         if not self._core_gnb_requirer.tac or not self._core_gnb_requirer.plmns:
             event.add_status(WaitingStatus("Waiting for TAC and PLMNs configuration"))
             return
+        if not self._is_gnb_name_published():
+            event.add_status(
+                BlockedStatus(
+                    "Invalid configuration: gNB name is missing from the relation"
+                )
+            )
+            return
         event.add_status(
             ActiveStatus(
                 f"PLMNs: {','.join([str(plmn.asdict()) for plmn in self._core_gnb_requirer.plmns])}, "  # noqa: E501
@@ -58,7 +65,10 @@ class SdcoreGnbIntegratorCharm(ops.CharmBase):
             logger.info("No %s relations found.", CORE_GNB_RELATION_NAME)
             return
 
-        self._core_gnb_requirer.publish_gnb_information(gnb_name=self._gnb_name)
+        try:
+            self._core_gnb_requirer.publish_gnb_information(gnb_name=self._gnb_name)
+        except ValueError:
+            return
 
     def _relation_created(self, relation_name: str) -> bool:
         """Return whether a given Juju relation was created.
@@ -79,6 +89,12 @@ class SdcoreGnbIntegratorCharm(ops.CharmBase):
             str: the gNB's name.
         """
         return f"{self.model.name}-gnb-{self.app.name}"
+
+    def _is_gnb_name_published(self) -> bool:
+        relation = self.model.get_relation(CORE_GNB_RELATION_NAME)
+        if not relation:
+            return False
+        return relation.data[self.app].get("gnb-name") is not None
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -45,6 +45,22 @@ class TestCharmCollectUnitStatus(GnbIntegratorUnitTestFixtures):
 
         assert state_out.unit_status == WaitingStatus("Waiting for TAC and PLMNs configuration")
 
+    def test_fiveg_core_gnb_gnb_name_unavailable_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
+        self,
+    ):
+        self.mock_gnb_core_remote_tac.return_value = 1
+        self.mock_gnb_core_remote_plmns.return_value = PLMNConfig(mcc="001", mnc="01", sst=31)
+        core_gnb_relation = testing.Relation(
+                endpoint="fiveg_core_gnb", interface="fiveg_core_gnb"
+            )
+        state_in = testing.State(leader=True, relations=[core_gnb_relation])
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+            "Invalid configuration: gNB name is missing from the relation"
+        )
+
     @pytest.mark.parametrize(
         "tac,plmns",
         [
@@ -56,8 +72,10 @@ class TestCharmCollectUnitStatus(GnbIntegratorUnitTestFixtures):
         self.mock_gnb_core_remote_tac.return_value = tac
         self.mock_gnb_core_remote_plmns.return_value = plmns
         core_gnb_relation = testing.Relation(
-                endpoint="fiveg_core_gnb", interface="fiveg_core_gnb"
-            )
+            endpoint="fiveg_core_gnb",
+            interface="fiveg_core_gnb",
+            local_app_data={"gnb-name": "gnb-integrator"},
+        )
         state_in = testing.State(leader=True, relations=[core_gnb_relation])
 
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)


### PR DESCRIPTION
# Description

This PR adds the check for the presence of `gnb-name` in the local databag for the `fiveg_core_gnb` relation. If the gNB name is not published, the charm remains in `Blocked` status.
This PR is necessary after [this improvement](https://github.com/canonical/sdcore-nms-k8s-operator/pull/464), as the gNB  name may not pass the validation and therefore not be published in the library (and then added to NMS).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
